### PR TITLE
Methods for handling duplicates 

### DIFF
--- a/pictory/pictory.py
+++ b/pictory/pictory.py
@@ -13,21 +13,21 @@ from typing import (
 count_int = 0
 
 
-def over_strategy(src, des_path, filename)-> None:
+def over_strategy(src, des_path, filename) -> None:
     shutil.move(src, os.path.join(des_path, filename))
 
 
-def pref_strategy(src, des_path, filename)-> None:
+def pref_strategy(src, des_path, filename) -> None:
     global count_int
     count_int += 1
-    new_filename = str(count_int) + '_' + filename
+    new_filename = "{}_{}".format(str(count_int), filename)
     shutil.copy(src, os.path.join(des_path, new_filename))
 
 
 def suff_strategy(src, des_path, filename) -> None:
     global count_int
     count_int += 1
-    new_filename = filename.split('.')[0] + '_' + str(count_int) + '.' + filename.split('.')[1]
+    new_filename =  "{}_{}.{}".format(filename.split('.')[0], str(count_int), filename.split('.')[1])
     shutil.copy(src, os.path.join(des_path, new_filename))
 
 


### PR DESCRIPTION
Issue: #1 

## Comment on the PR  
First was added the argument parse, with first argument the path and second --duplicates, optional
(default value skip)
The argument duplicates have 4 choices: [skip, over, pref, suff] 
- skip: skip the duplicated file
- over: overwrite the duplicated file
- pref:  add a prefix to the duplicated file
- suff: add a suffix to the duplicated file

The way this is handled is with a dictionary where the keys  are the 4 choices and the value are the functions that implement that behaviour.

In this way should be easy to change the strings or the expected behaviour.

## Improvement
The only part I don't really like is the global variable count_int that is used for adding the right prefix/suffix.
That can be improved
